### PR TITLE
updated kebab-case naming consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install sushi-train
 Import the package and use the small focused utilities. The library exposes short, composable functions so you can grab them off the sushi train and into data pipelines:
 
 ```python
-from sushi_train import add_query_params_to_url
+from sushi-train import add_query_params_to_url
 
 url = "https://example.com/api"
 params = {"roll": "spicy-tuna",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "sushi_train"
+name = "sushi-train"
 version = "0.1.3"
 description = "Like a sushi train, but for data engineering. Grab a utility function when you want it, and leave it if you don't."
 license = {text = "MIT"}
@@ -26,7 +26,7 @@ requires = ["hatchling >= 1.26"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/sushi_train"]
+packages = ["src/sushi-train"]
 
 [project.urls]
-Homepage = "https://github.com/MichaelGalo/sushi_train"
+Homepage = "https://github.com/MichaelGalo/sushi-train"

--- a/src/sushi_train/__init__.py
+++ b/src/sushi_train/__init__.py
@@ -1,8 +1,8 @@
 
-"""Top-level package API for sushi_train.
+"""Top-level package API for sushi-train.
 
 This module re-exports selected functions from the submodules so users
-can do `import sushi_train` and access the common helpers directly.
+can do `import sushi-train` and access the common helpers directly.
 """
 
 from .data_io.duckdb import (

--- a/tests/test_data_io_local.py
+++ b/tests/test_data_io_local.py
@@ -1,7 +1,7 @@
 
 import polars as pl
 
-from sushi_train.data_io.local import (
+from sushi-train.data_io.local import (
 	write_dataframe_to_local_csv,
 	read_local_csv_to_dataframe,
 	write_dataframe_to_local_parquet,


### PR DESCRIPTION
# Description

This pull request updates the package name from `sushi_train` to `sushi-train` throughout the codebase and documentation to ensure consistency and proper import usage. The changes affect configuration files, documentation, and import statements.

**Package name and import updates:**

* Renamed the package in `pyproject.toml` from `sushi_train` to `sushi-train`, and updated the homepage URL to match the new naming convention. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L2-R2) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L29-R32)
* Changed all import statements in documentation (`README.md`), source code (`src/sushi_train/__init__.py`), and tests (`tests/test_data_io_local.py`) to use `sushi-train` instead of `sushi_train`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R34) [[2]](diffhunk://#diff-aac9a32af349a18c1ce0b4754a55cde96dfc4fc48fed67f1c7bf14494241b685L2-R5) [[3]](diffhunk://#diff-b46b2de197de426e5d76c359a29a69c60173f3e8a0bbf26cff63bf4e037e88d4L4-R4)
* Updated the package path in the build configuration from `src/sushi_train` to `src/sushi-train` in `pyproject.toml`.


## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Chore
